### PR TITLE
chore(download): Link Bluefin documentation

### DIFF
--- a/components/sections/download/check-docs.tsx
+++ b/components/sections/download/check-docs.tsx
@@ -2,8 +2,8 @@ export default function CheckDocs() {
   return (
     <div className={"w-full"}>
       <div className={"italic text-aurora-darkblue"}>
-        Checkout the <a className={"underline"} href={"https://universal-blue.discourse.group/docs?topic=2291"}>docs
-        here.</a>
+        Check out the <a className={"underline"} href={"https://universal-blue.discourse.group/docs?topic=2291"}> Bluefin documentation
+        here.</a> Most of it applies besides anything that is GNOME specific.
       </div>
       <div className={"italic text-aurora-darkblue"}>
         Checkout the <a className={"underline"} href={"https://universal-blue.discourse.group/docs?topic=1235"}>Introduction


### PR DESCRIPTION
This can be a temporary workaround if you plan to include Aurora specific documentation, but I figured most of it would be repeated from Bluefin outside of the GNOME stuff.