### PR TITLE
chore(faq): Remove documentation link, add forum link

### DIFF
--- a/components/sections/about/faq/questions.ts
+++ b/components/sections/about/faq/questions.ts
@@ -15,9 +15,9 @@ export const questions: Question[] = [
     optionalLink: ""
   },
   {
-    question: "Where can I learn more or get documentation about Aurora and Aurora-DX?",
-    answer: "Checkout our docs site on the Discourse, you can find lot's of helpful material there.",
-    optionalLink: "https://universal-blue.discourse.group/docs?category=6"
+    question: "Where can I get the latest news and discussions about Aurora?",
+    answer: "Check out our Discourse forums for the latest updates and discussions on Aurora.",
+    optionalLink: "https://universal-blue.discourse.group/c/bluefin/6"
   }
 ];
 


### PR DESCRIPTION
If https://github.com/NiHaiden/aurora-web/pull/8 merges, then it would be best to not repeat this and link directly to the forum.