### PR TITLE
Updated to new documentation website

### DIFF
--- a/components/sections/download/check-docs.tsx
+++ b/components/sections/download/check-docs.tsx
@@ -2,12 +2,8 @@ export default function CheckDocs() {
   return (
     <div className={"w-full"}>
       <div className={"italic text-aurora-darkblue"}>
-        Check out the <a className={"underline"} href={"https://docs.getaurora.dev/"}> documentation
+        Check out the <a className={"underline"} href={"https://docs.getaurora.dev/guides/intro/"}> documentation
         here.</a>
-      </div>
-      <div className={"italic text-aurora-darkblue"}>
-        Check out the <a className={"underline"} href={"https://docs.getaurora.dev/guides/intro/"}>Introduction
-        to Aurora.</a>
       </div>
     </div>
   );

--- a/components/sections/download/check-docs.tsx
+++ b/components/sections/download/check-docs.tsx
@@ -2,7 +2,7 @@ export default function CheckDocs() {
   return (
     <div className={"w-full"}>
       <div className={"italic text-aurora-darkblue"}>
-        Check out the <a className={"underline"} href={"https://docs.projectbluefin.io/"}> documentation
+        Check out the <a className={"underline"} href={"https://docs.getaurora.dev/"}> documentation
         here.</a>
       </div>
       <div className={"italic text-aurora-darkblue"}>

--- a/components/sections/download/check-docs.tsx
+++ b/components/sections/download/check-docs.tsx
@@ -2,8 +2,8 @@ export default function CheckDocs() {
   return (
     <div className={"w-full"}>
       <div className={"italic text-aurora-darkblue"}>
-        Check out the <a className={"underline"} href={"https://docs.projectbluefin.io/"}> Bluefin documentation
-        here.</a> Most of it applies besides anything that is GNOME specific.
+        Check out the <a className={"underline"} href={"https://docs.projectbluefin.io/"}> documentation
+        here.</a>
       </div>
       <div className={"italic text-aurora-darkblue"}>
         Check out the <a className={"underline"} href={"https://docs.getaurora.dev/guides/intro/"}>Introduction


### PR DESCRIPTION
By the way Niklas, I have plans to add more docs and maybe reference a link to the Bluefin documentation on the home page eventually when I get around to it.  I also think the .desktop "documentation" shortcut should point to [Documentation landing page on Discourse](https://universal-blue.discourse.group/t/documentation/3147) since both Bluefin and Aurora share the menu shortcut.