### PR TITLE
Fix broken docs link

### DIFF
--- a/components/sections/download/check-docs.tsx
+++ b/components/sections/download/check-docs.tsx
@@ -5,7 +5,7 @@ export default function CheckDocs() {
         Check out the{" "}
         <a
           className={"underline"}
-          href={"https://docs.getaurora.dev/guides/intro/"}
+          href={"https://docs.getaurora.dev"}
         >
           {" "}
           documentation here.


### PR DESCRIPTION
Currently the link gets a

> Page Not Found
> 
> We could not find what you were looking for.
> 
> Please contact the owner of the site that linked you to the original URL and let them know their link is broken.