### PR TITLE
(DO NOT MERGE YET!!!) experimental aurora-news tag for news

### DIFF
--- a/components/sections/news.tsx
+++ b/components/sections/news.tsx
@@ -69,6 +69,6 @@ export default function News({ newsRef }: { newsRef: RefObject<any> }) {
 function discourseTopics() {
   return {
     __html:
-      ' <d-topics-list discourse-url="https://universal-blue.discourse.group" per-page="5" tags="bluefin-news" template="complete"></d-topics-list> ',
+      ' <d-topics-list discourse-url="https://universal-blue.discourse.group" per-page="5" tags="aurora-news" template="complete"></d-topics-list> ',
   };
 }


### PR DESCRIPTION
## DO NOT MERGE YET!

I need to discuss this with Jorge eventually, but we have hidden tags for the website news sections (bazzite-news, bluefin-news, ublue-news) but aurora was only using the current bluefin-news tag since it was, once upon a time, part of the same repo.  

## Issues if merged prematurely

We lose all the previous news which might be okay to start fresh (since I feel like we are and will eventually drift away from "Bluefin but KDE Plasma").

Cc: @NiHaiden