### PR TITLE
Update download links to webui version

### DIFF
--- a/components/sections/download/download.tsx
+++ b/components/sections/download/download.tsx
@@ -210,8 +210,8 @@ function DownloadButtons({
   isHelium: boolean;
   isx86?: boolean;
 }) {
-  const downloadLink: string = `https://dl.getaurora.dev/${imageName}-x86_64.iso`;
-  const checksumLink: string = `https://dl.getaurora.dev/${imageName}-x86_64.iso-CHECKSUM`;
+  const downloadLink: string = `https://dl.getaurora.dev/${imageName}-webui-x86_64.iso`; 
+  const checksumLink: string = `https://dl.getaurora.dev/${imageName}-webui-x86_64.iso-CHECKSUM`;
   const t = useTranslations("Download-Component");
 
   return (


### PR DESCRIPTION
Update the links to point to the WebUI version of our ISOs.

I have done these test with successfull installations:
- VM install with no LUKS/encrypion
- VM install with LUKS/encryption
- bare-metal install with LUKS/encryption