### PR TITLE
fix: properly render navbar on page reload

### DIFF
--- a/components/nav/SharedNavbar.tsx
+++ b/components/nav/SharedNavbar.tsx
@@ -24,6 +24,7 @@ const SharedNavbar = ({ variant = "page", onScrollTo }: SharedNavbarProps) => {
     const handleScroll = () => {
       setIsTop(window.scrollY <= 100);
     };
+    handleScroll();
     document.addEventListener("scroll", handleScroll);
     return () => document.removeEventListener("scroll", handleScroll);
   }, []);


### PR DESCRIPTION
Call handleScroll() once when the useEffect() hook is added to the navbar. This checks the page position once on (re)load to ensure the navbar is rendered as expected. Closes #208 