### PR TITLE
chore: rename "Fedora Image Writer" to "Fedora Media Writer"

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -33,7 +33,7 @@
 		"nvidia-subtitle": "RTX-Serie / GTX 16xx · Proprietär",
 		"installation-guide": "Installationsanleitung",
 		"recommend-using": "Wir empfehlen",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "um deinen Installations-USB-Stick zu erstellen.",
 		"note": "Hinweis:",
 		"ventoy-not-supported": "Ventoy wird mit unseren ISO-Dateien nicht unterstützt.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -33,7 +33,7 @@
 		"nvidia-subtitle": "RTX-Series / GTX 16xx - Open-Nvidia drivers",
 		"installation-guide": "Installation Guide",
 		"recommend-using": "We recommend using",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "to create your installation USB drive.",
 		"note": "Note:",
 		"ventoy-not-supported": "Ventoy is not supported with our ISO files.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,7 +31,7 @@
 		"nvidia": "Nvidia (Serie RTX/GTX 16xx)",
 		"installation-guide": "Guía de Instalación",
 		"recommend-using": "Recomendamos usar",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "para crear la instalación en el flash USB.",
 		"note": "Nota:",
 		"ventoy-not-supported": "Ventoy no está soportado con nuestros ISO.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -32,7 +32,7 @@
 		"nvidia": "Nvidia (Série RTX/GTX 16xx)",
 		"installation-guide": "Guide d'installation",
 		"recommend-using": "Nous recommandons d'utiliser",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "pour créer votre clé USB d'installation.",
 		"note": "Note : ",
 		"ventoy-not-supported": "Ventoy est incompatible avec nos fichiers ISO.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -31,7 +31,7 @@
 		"nvidia": "Nvidia (RTX-Series/GTX 16xx)",
 		"installation-guide": "Przewodnik po instalacji",
 		"recommend-using": "Polecamy użyć",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "do stworzenia instalacyjnego nośnika USB.",
 		"note": "Uwaga:",
 		"ventoy-not-supported": "Ventoy nie jest wspierany przez nasze nośniki ISO.",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -33,7 +33,7 @@
 		"nvidia-subtitle": "RTX-Series / GTX 16xx · Proprietário",
 		"installation-guide": "Guia de instalação",
 		"recommend-using": "Recomendamos usar",
-		"fedora-image-writer": "o Fedora Image Writer",
+		"fedora-image-writer": "o Fedora Media Writer",
 		"create-usb": "para criar uma drive de instalação USB.",
 		"note": "Nota:",
 		"ventoy-not-supported": "Ventoy não é suportado com o nosso ficheiro ISO.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -33,7 +33,7 @@
 		"nvidia-subtitle": "RTX-серии / GTX 16xx · Проприетарные",
 		"installation-guide": "Инструкция по установке",
 		"recommend-using": "Мы рекомендуем использовать",
-		"fedora-image-writer": "Fedora Image Writer",
+		"fedora-image-writer": "Fedora Media Writer",
 		"create-usb": "для создания вашей установочной USB флешки.",
 		"note": "Примечание:",
 		"ventoy-not-supported": "Ventoy не поддерживает наши файлы ISO.",


### PR DESCRIPTION
oops closed by accident
This renames FMW on the downloads page to match its actual name